### PR TITLE
hotfix: corrected server join date

### DIFF
--- a/src/commands/tools/user.js
+++ b/src/commands/tools/user.js
@@ -42,7 +42,7 @@ module.exports = {
                 { name: '**__Is System__**', value: `${target.system}`, inline: true },
                 { name: '**__User ID__**', value: `${target.id}`, inline: true },
                 { name: '**__Discord Join Date__**', value: `<t:${target.createdTimestamp.toString().substring(0,10)}:F> <t:${target.createdTimestamp.toString().substring(0,10)}:R>`},
-                { name: '**__Server Join Date__**', value: `<t:${interaction.member.joinedTimestamp.toString().substring(0,10)}:F> <t:${interaction.member.joinedTimestamp.toString().substring(0,10)}:R>`},
+                { name: '**__Server Join Date__**', value: `<t:${joinedTimestamp.toString().substring(0,10)}:F> <t:${joinedTimestamp.toString().substring(0,10)}:R>`},
                 // { name: '\u200B', value: '\u200B' }, // spacer
             )
             // .setImage()

--- a/src/commands/tools/user.js
+++ b/src/commands/tools/user.js
@@ -22,8 +22,16 @@ module.exports = {
         console.log(target.createdAt);
         console.log(target.createdTimestamp);
         console.log(target.joinedTimestamp);
-        console.log(interaction.member);
-        console.log(interaction);
+
+        const userr = interaction.options.getUser('user');
+        const memberr = interaction.guild.members.cache.get(userr.id);
+
+        const joinedTimestamp = memberr.joinedTimestamp;
+
+        console.log(joinedTimestamp);
+
+        // console.log(interaction.member);
+        // console.log(interaction);
         
 
         const userEmbed = new EmbedBuilder()

--- a/src/commands/tools/user.js
+++ b/src/commands/tools/user.js
@@ -22,6 +22,8 @@ module.exports = {
         console.log(target.createdAt);
         console.log(target.createdTimestamp);
         console.log(target.joinedTimestamp);
+        console.log(interaction.member);
+        console.log(interaction);
         
 
         const userEmbed = new EmbedBuilder()

--- a/src/commands/tools/user.js
+++ b/src/commands/tools/user.js
@@ -19,12 +19,12 @@ module.exports = {
 
         const target = interaction.options.getUser('user');
         const silence = interaction.options.getBoolean('silent') || false;
-        console.log(target.createdAt);
-        console.log(target.createdTimestamp);
+        // console.log(target.createdAt);
+        // console.log(target.createdTimestamp);
 
         var createdTimestamp = `<t:${target.createdTimestamp.toString().substring(0,10)}:F> <t:${target.createdTimestamp.toString().substring(0,10)}:R>`
 
-        console.log(target.joinedTimestamp);
+        // console.log(target.joinedTimestamp);
 
         var joinedTimestamp;
         
@@ -32,12 +32,11 @@ module.exports = {
             joinedTimestamp = interaction.guild.members.cache.get(interaction.options.getUser('user').id).joinedTimestamp;
             joinedTimestamp = `<t:${joinedTimestamp.toString().substring(0,10)}:F> <t:${joinedTimestamp.toString().substring(0,10)}:R>`
         } catch (error) {
-            console.log(error);
+            // console.log(error);
             joinedTimestamp = `User not in this server`;
         }
 
-        console.log(joinedTimestamp);
-        
+        // console.log(joinedTimestamp);
 
         const userEmbed = new EmbedBuilder()
             .setColor(0x8B41C8)

--- a/src/commands/tools/user.js
+++ b/src/commands/tools/user.js
@@ -21,6 +21,8 @@ module.exports = {
         const silence = interaction.options.getBoolean('silent') || false;
         console.log(target.createdAt);
         console.log(target.createdTimestamp);
+        console.log(target.joinedTimestamp);
+        
 
         const userEmbed = new EmbedBuilder()
             .setColor(0x8B41C8)

--- a/src/commands/tools/user.js
+++ b/src/commands/tools/user.js
@@ -21,14 +21,22 @@ module.exports = {
         const silence = interaction.options.getBoolean('silent') || false;
         console.log(target.createdAt);
         console.log(target.createdTimestamp);
+
+        var createdTimestamp = `<t:${target.createdTimestamp.toString().substring(0,10)}:F> <t:${target.createdTimestamp.toString().substring(0,10)}:R>`
+
         console.log(target.joinedTimestamp);
 
-        const joinedTimestamp = interaction.guild.members.cache.get(interaction.options.getUser('user').id).joinedTimestamp;
+        var joinedTimestamp;
+        
+        try {
+            joinedTimestamp = interaction.guild.members.cache.get(interaction.options.getUser('user').id).joinedTimestamp;
+            joinedTimestamp = `<t:${joinedTimestamp.toString().substring(0,10)}:F> <t:${joinedTimestamp.toString().substring(0,10)}:R>`
+        } catch (error) {
+            console.log(error);
+            joinedTimestamp = `User not in this server`;
+        }
 
         console.log(joinedTimestamp);
-
-        // console.log(interaction.member);
-        // console.log(interaction);
         
 
         const userEmbed = new EmbedBuilder()
@@ -41,8 +49,8 @@ module.exports = {
                 { name: '**__Is Bot__**', value: `${target.bot}`, inline: true },
                 { name: '**__Is System__**', value: `${target.system}`, inline: true },
                 { name: '**__User ID__**', value: `${target.id}`, inline: true },
-                { name: '**__Discord Join Date__**', value: `<t:${target.createdTimestamp.toString().substring(0,10)}:F> <t:${target.createdTimestamp.toString().substring(0,10)}:R>`},
-                { name: '**__Server Join Date__**', value: `<t:${joinedTimestamp.toString().substring(0,10)}:F> <t:${joinedTimestamp.toString().substring(0,10)}:R>`},
+                { name: '**__Discord Join Date__**', value: `${createdTimestamp}`},
+                { name: '**__Server Join Date__**', value: `${joinedTimestamp}`},
                 // { name: '\u200B', value: '\u200B' }, // spacer
             )
             // .setImage()

--- a/src/commands/tools/user.js
+++ b/src/commands/tools/user.js
@@ -23,10 +23,7 @@ module.exports = {
         console.log(target.createdTimestamp);
         console.log(target.joinedTimestamp);
 
-        const userr = interaction.options.getUser('user');
-        const memberr = interaction.guild.members.cache.get(userr.id);
-
-        const joinedTimestamp = memberr.joinedTimestamp;
+        const joinedTimestamp = interaction.guild.members.cache.get(interaction.options.getUser('user').id).joinedTimestamp;
 
         console.log(joinedTimestamp);
 


### PR DESCRIPTION
was defaulted to the executor's server join date, and correctly handles user id's that are not apart of the same server